### PR TITLE
feat: 크롤러 서비스 구현 및 Worker Pool 패턴 적용

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/Go-studyy-main.iml
+++ b/.idea/Go-studyy-main.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/go.imports.xml
+++ b/.idea/go.imports.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoImports">
+    <option name="excludedPackages">
+      <array>
+        <option value="github.com/pkg/errors" />
+        <option value="golang.org/x/net/context" />
+      </array>
+    </option>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Go-studyy-main.iml" filepath="$PROJECT_DIR$/.idea/Go-studyy-main.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -10,41 +10,88 @@ const UserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6)" +
 	" AppleWebKit/537.36 (KHTML, like Gecko)" +
 	" Chrome/79.0.3945.130 Safari/537.36"
 
+var httpClient = &http.Client{}
+
+type Job struct {
+	URL  string
+	Link *NewsLink
+}
+
 func Crawler(index NewsIndex, useGoroutine bool) error {
-	var wg sync.WaitGroup
-	for i, link := range index.Link {
-		wg.Add(1)
-		if useGoroutine {
-			go GetContent(link.URI, &index.Link[i], &wg)
-		} else {
-			err := GetContent(link.URI, &index.Link[i], &wg)
-			if err != nil {
+	if !useGoroutine {
+		for i := range index.Link {
+			if err := fetchContent(index.Link[i].URI, &index.Link[i]); err != nil {
 				return err
 			}
 		}
+		return nil
 	}
+
+	// Worker pool로 병렬 처리(최대 10개 동시 연결)
+	const numWorkers = 10
+	jobs := make(chan Job, len(index.Link))
+	errChan := make(chan error, 1)
+	var wg sync.WaitGroup
+
+	// Worker 시작
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go worker(jobs, errChan, &wg)
+	}
+
+	// Job 시작
+	for i := range index.Link {
+		jobs <- Job{
+			URL:  index.Link[i].URI,
+			Link: &index.Link[i],
+		}
+	}
+	close(jobs)
+
 	wg.Wait()
+	close(errChan)
+
 	return nil
 }
 
-func GetContent(
-	url string, link *NewsLink, wg *sync.WaitGroup) error {
-	client := &http.Client{}
+func worker(jobs <-chan Job, errChan chan<- error, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	for job := range jobs {
+		if err := fetchContent(job.URL, job.Link); err != nil {
+			select {
+			case errChan <- err:
+			default:
+			}
+		}
+	}
+}
+
+func fetchContent(url string, link *NewsLink) error {
 	req, err := http.NewRequest("GET", url, nil)
-	req.Close = true
-	req.Header.Add("User-Agent", UserAgent)
-	resp, err := client.Do(req)
 	if err != nil {
-		wg.Done()
+		return err
+	}
+
+	req.Header.Add("User-Agent", UserAgent)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		wg.Done()
 		return err
 	}
+
 	link.Content = string(body)
-	wg.Done()
 	return nil
+}
+
+// 하위 호환성을 위해 유지
+func GetContent(url string, link *NewsLink, wg *sync.WaitGroup) error {
+	defer wg.Done()
+	return fetchContent(url, link)
 }

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -1,0 +1,50 @@
+package crawler
+
+import (
+	"io"
+	"net/http"
+	"sync"
+)
+
+const UserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6)" +
+	" AppleWebKit/537.36 (KHTML, like Gecko)" +
+	" Chrome/79.0.3945.130 Safari/537.36"
+
+func Crawler(index NewsIndex, useGoroutine bool) error {
+	var wg sync.WaitGroup
+	for i, link := range index.Link {
+		wg.Add(1)
+		if useGoroutine {
+			go GetContent(link.URI, &index.Link[i], &wg)
+		} else {
+			err := GetContent(link.URI, &index.Link[i], &wg)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	wg.Wait()
+	return nil
+}
+
+func GetContent(
+	url string, link *NewsLink, wg *sync.WaitGroup) error {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	req.Close = true
+	req.Header.Add("User-Agent", UserAgent)
+	resp, err := client.Do(req)
+	if err != nil {
+		wg.Done()
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		wg.Done()
+		return err
+	}
+	link.Content = string(body)
+	wg.Done()
+	return nil
+}

--- a/crawler/index.go
+++ b/crawler/index.go
@@ -1,0 +1,43 @@
+package crawler
+
+import (
+	"io"
+	"net/http"
+)
+
+var ITNewsURIs = []string{
+	"https://news.hada.io/",
+	"https://news.hada.io/past",
+	"https://news.hada.io/new",
+}
+
+type NewsLink struct {
+	URI     string
+	Title   string
+	Content string
+}
+
+type NewsIndex struct {
+	Link []NewsLink
+}
+
+func Indexing() (newsIndex NewsIndex, err error) {
+	index := NewsIndex{[]NewsLink{}}
+	for _, url := range ITNewsURIs {
+		resp, err := http.Get(url)
+		if err != nil {
+			return NewsIndex{}, err
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		titleUrlPair := ParseIndex(body)
+		for _, pair := range titleUrlPair {
+			index.Link = append(index.Link, NewsLink{
+				URI:   pair[0],
+				Title: pair[1],
+			})
+		}
+	}
+
+	return index, nil
+}

--- a/crawler/parser.go
+++ b/crawler/parser.go
@@ -1,0 +1,16 @@
+package crawler
+
+import "regexp"
+
+func ParseIndex(data []byte) [][]string {
+	regexpString := `<div class=topictitle><a href='(https://[^']*)'[^>]*><h1>(.*?)</h1></a>`
+
+	re := regexp.MustCompile(regexpString)
+	content := string(data)
+	matches := re.FindAllStringSubmatch(content, -1)
+	urlTitlePair := make([][]string, len(matches))
+	for i, value := range matches {
+		urlTitlePair[i] = []string{value[1], value[2]}
+	}
+	return urlTitlePair
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Go-Studying/Go-studyy
+
+go 1.24.0
+
+require golang.org/x/time v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,1 @@
+golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Go-Studying/Go-studyy/crawler"
+)
+
+const divideBar = "=============="
+
+func main() {
+	var confirm string
+	useGoroutine := false
+	fmt.Print("고루틴을 사용하시겠습니까? (y/N): ")
+	fmt.Scanf("%s\n", &confirm)
+
+	if strings.ToUpper(confirm) == "y" {
+		useGoroutine = true
+	}
+
+	index, err := crawler.Indexing()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(divideBar)
+	fmt.Printf("총 %d건의 뉴스 기사를 찾았습니다.\n", len(index.Link))
+	fmt.Printf("뉴스 내용을 불러옵니다")
+
+	start := time.Now()
+	err = crawler.Crawler(index, useGoroutine)
+	if err != nil {
+		panic(err)
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("모든 뉴스 내용을 불러왔습니다.")
+	fmt.Println(divideBar)
+	for _, link := range index.Link {
+		fmt.Printf("TITLE: %v\n", link.Title)
+		fmt.Printf("LINK : %v\n", link.URI)
+		fmt.Printf("CONTENT: %d 글자의 내용\n", len(link.Content))
+		fmt.Println(divideBar)
+	}
+	fmt.Printf("소요시간: %v\n", elapsed)
+}


### PR DESCRIPTION
## #️⃣ Issue Number

> Closed #3 

## 📝 요약(Summary)
> news.hada.io에서 IT 뉴스를 수집하는 크롤러 서비스 구현(고루틴 + Worker Pool 패턴)

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 처음에 책에 나온대로 구현을 했을때 오히려 고루틴 사용시 좀 느렸습니다. 
- 원인을 찾다보니 http keep-alive, 동시 연결 수 제한 등의 문제가 있었습니다.

## http keep-alive 관련 문제
`req.Close = true`
이 설정에서 
```
요청 1: TCP 연결 생성 -> HTTP 요청 -> 응답 -> 연결 종료
요청 2: TCP 연결 생성 -> HTTP 요청 -> 응답 -> 연결 종료
요청 3: TCP 연결 생성 -> HTTP 요청 -> 응답 -> 연결 종료
```


위의 코드를 제거하고 전역 클라이언트로 생성을 하면
`var httpClient = &http.Client{}`

TCP를 한번만 만들고 재사용하는 방식으로 
```
요청 1: TCP 연결 생성 -> HTTP 요청 -> 응답 
요청 2: TCP 재사용 -> HTTP 요청 -> 응답
```
하는 구조로 지연 시간이 감소됩니다.

## 동시 연결 수 제한의 장점
- 저는 처음에 44개 요청을 한번에 모두 시작하였습니다.
- 근데 로컬 시스템이 과부하가 걸렸는지 순차처리랑 비슷하게 시간이 나온 경우가 있습니다.
- 따라서 이것저것 서치를 하다 보니 worker pool 패턴으로 동시 연결 수를 제한을 걸 수 있었습니다.
- 여러 가지의 수를 적용해보며 최적의 worker pool 수을 찾아 고루틴의 경우가 더 빨라진 결과를 얻을 수 있었어요!
- 이런 방법으로도 커스터마이징을 하며 최적의 방법을 찾을 수 있는거를 깨달았습니다!!
- 결과는 다음과 같아요

<img width="680" height="145" alt="스크린샷 2026-01-20 오후 4 52 51" src="https://github.com/user-attachments/assets/8c00ec1e-34a7-43f6-b10c-0da1059c130a" />
<img width="769" height="238" alt="스크린샷 2026-01-20 오후 4 52 56" src="https://github.com/user-attachments/assets/a48245e7-f3e8-46ab-a7a3-559e336db903" />

- 위의 사진이 순차처리이고, 밑사진이 고루틴 결과입니다!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
